### PR TITLE
ssz, tests: restore non-monolith API, add README sections

### DIFF
--- a/example_asymmetric_test.go
+++ b/example_asymmetric_test.go
@@ -41,11 +41,11 @@ func (w *WithdrawalAsym) DefineSSZ(codec *ssz.Codec) {
 }
 
 func ExampleEncodeAsymmetricObject() {
-	blob := make([]byte, ssz.Size((*WithdrawalAsym)(nil), ssz.ForkUnknown))
-	if err := ssz.EncodeToBytes(blob, new(WithdrawalAsym), ssz.ForkUnknown); err != nil {
+	blob := make([]byte, ssz.Size((*WithdrawalAsym)(nil)))
+	if err := ssz.EncodeToBytes(blob, new(WithdrawalAsym)); err != nil {
 		panic(err)
 	}
-	hash := ssz.HashSequential(new(WithdrawalAsym), ssz.ForkUnknown)
+	hash := ssz.HashSequential(new(WithdrawalAsym))
 
 	fmt.Printf("ssz: %#x\nhash: %#x\n", blob, hash)
 	// Output:

--- a/example_checked_test.go
+++ b/example_checked_test.go
@@ -30,7 +30,7 @@ func ExampleDecodeCheckedObject() {
 	blob := make([]byte, 44)
 
 	obj := new(WithdrawalChecked)
-	if err := ssz.DecodeFromBytes(blob, obj, ssz.ForkUnknown); err != nil {
+	if err := ssz.DecodeFromBytes(blob, obj); err != nil {
 		panic(err)
 	}
 	fmt.Printf("obj: %#x\n", obj)

--- a/example_dynamic_test.go
+++ b/example_dynamic_test.go
@@ -72,8 +72,8 @@ func (e *ExecutionPayload) DefineSSZ(codec *ssz.Codec) {
 func ExampleEncodeDynamicObject() {
 	obj := new(ExecutionPayload)
 
-	blob := make([]byte, ssz.Size(obj, ssz.ForkUnknown))
-	if err := ssz.EncodeToBytes(blob, obj, ssz.ForkUnknown); err != nil {
+	blob := make([]byte, ssz.Size(obj))
+	if err := ssz.EncodeToBytes(blob, obj); err != nil {
 		panic(err)
 	}
 	fmt.Printf("ssz: %#x\n", blob)

--- a/example_static_test.go
+++ b/example_static_test.go
@@ -31,10 +31,10 @@ func (w *Withdrawal) DefineSSZ(codec *ssz.Codec) {
 
 func ExampleEncodeStaticObject() {
 	out := new(bytes.Buffer)
-	if err := ssz.EncodeToStream(out, new(Withdrawal), ssz.ForkUnknown); err != nil {
+	if err := ssz.EncodeToStream(out, new(Withdrawal)); err != nil {
 		panic(err)
 	}
-	hash := ssz.HashSequential(new(Withdrawal), ssz.ForkUnknown)
+	hash := ssz.HashSequential(new(Withdrawal))
 
 	fmt.Printf("ssz: %#x\nhash: %#x\n", out, hash)
 	// Output:

--- a/hasher.go
+++ b/hasher.go
@@ -572,7 +572,7 @@ func HashSliceOfStaticObjects[T StaticObject](h *Hasher, objects []T, maxItems u
 	defer h.ascendMixinLayer(uint64(len(objects)), maxItems)
 
 	// If threading is disabled, or hashing nothing, do it sequentially
-	if !h.threads || len(objects) == 0 || len(objects)*int(Size(objects[0], h.codec.fork)) < concurrencyThreshold {
+	if !h.threads || len(objects) == 0 || len(objects)*int(SizeOnFork(objects[0], h.codec.fork)) < concurrencyThreshold {
 		for _, obj := range objects {
 			h.descendLayer()
 			obj.DefineSSZ(h.codec)

--- a/tests/corner_cases_test.go
+++ b/tests/corner_cases_test.go
@@ -19,19 +19,19 @@ import (
 func TestDecodeMissized(t *testing.T) {
 	obj := new(testMissizedType)
 
-	blob := make([]byte, ssz.Size(obj, ssz.ForkUnknown)+1)
-	if err := ssz.DecodeFromBytes(blob, obj, ssz.ForkUnknown); !errors.Is(err, ssz.ErrObjectSlotSizeMismatch) {
+	blob := make([]byte, ssz.Size(obj)+1)
+	if err := ssz.DecodeFromBytes(blob, obj); !errors.Is(err, ssz.ErrObjectSlotSizeMismatch) {
 		t.Errorf("decode from bytes error mismatch: have %v, want %v", err, ssz.ErrObjectSlotSizeMismatch)
 	}
-	if err := ssz.DecodeFromStream(bytes.NewReader(blob), obj, uint32(len(blob)), ssz.ForkUnknown); !errors.Is(err, ssz.ErrObjectSlotSizeMismatch) {
+	if err := ssz.DecodeFromStream(bytes.NewReader(blob), obj, uint32(len(blob))); !errors.Is(err, ssz.ErrObjectSlotSizeMismatch) {
 		t.Errorf("decode from stream error mismatch: have %v, want %v", err, ssz.ErrObjectSlotSizeMismatch)
 	}
 
-	blob = make([]byte, ssz.Size(obj, ssz.ForkUnknown)-1)
-	if err := ssz.DecodeFromBytes(blob, obj, ssz.ForkUnknown); !errors.Is(err, io.ErrUnexpectedEOF) {
+	blob = make([]byte, ssz.Size(obj)-1)
+	if err := ssz.DecodeFromBytes(blob, obj); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Errorf("decode from bytes error mismatch: have %v, want %v", err, io.ErrUnexpectedEOF)
 	}
-	if err := ssz.DecodeFromStream(bytes.NewReader(blob), obj, uint32(len(blob)), ssz.ForkUnknown); !errors.Is(err, io.ErrUnexpectedEOF) {
+	if err := ssz.DecodeFromStream(bytes.NewReader(blob), obj, uint32(len(blob))); !errors.Is(err, io.ErrUnexpectedEOF) {
 		t.Errorf("decode from stream error mismatch: have %v, want %v", err, io.ErrUnexpectedEOF)
 	}
 }
@@ -50,11 +50,11 @@ func (t *testMissizedType) DefineSSZ(codec *ssz.Codec) {
 func TestEncodeOversized(t *testing.T) {
 	obj := new(testMissizedType)
 
-	blob := make([]byte, ssz.Size(obj, ssz.ForkUnknown)-1)
-	if err := ssz.EncodeToBytes(blob, obj, ssz.ForkUnknown); !errors.Is(err, ssz.ErrBufferTooSmall) {
+	blob := make([]byte, ssz.Size(obj)-1)
+	if err := ssz.EncodeToBytes(blob, obj); !errors.Is(err, ssz.ErrBufferTooSmall) {
 		t.Errorf("encode to bytes error mismatch: have %v, want %v", err, ssz.ErrBufferTooSmall)
 	}
-	if err := ssz.EncodeToStream(&testEncodeOversizedStream{blob}, obj, ssz.ForkUnknown); err == nil {
+	if err := ssz.EncodeToStream(&testEncodeOversizedStream{blob}, obj); err == nil {
 		t.Errorf("encode to stream error mismatch: have nil, want stream full") // wonky, but should be fine
 	}
 }
@@ -85,7 +85,7 @@ func TestZeroCounterOffset(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	err = ssz.DecodeFromBytes(inSSZ, new(types.ExecutionPayload), ssz.ForkUnknown)
+	err = ssz.DecodeFromBytes(inSSZ, new(types.ExecutionPayload))
 	if !errors.Is(err, ssz.ErrZeroCounterOffset) {
 		t.Errorf("decode error mismatch: have %v, want %v", err, ssz.ErrZeroCounterOffset)
 	}
@@ -97,7 +97,7 @@ func TestInvalidBoolean(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	err = ssz.DecodeFromBytes(inSSZ, new(types.Validator), ssz.ForkUnknown)
+	err = ssz.DecodeFromBytes(inSSZ, new(types.Validator))
 	if !errors.Is(err, ssz.ErrInvalidBoolean) {
 		t.Errorf("decode error mismatch: have %v, want %v", err, ssz.ErrInvalidBoolean)
 	}

--- a/tests/zeroval_test.go
+++ b/tests/zeroval_test.go
@@ -19,11 +19,11 @@ func testZeroValue[T newableObject[U], U any](t *testing.T, fork ssz.Fork) {
 	// Verify that streaming/buffering encoding of a zero value results in the
 	// same binary (maybe incorrect, we just want to see that they're the same).
 	str1 := new(bytes.Buffer)
-	if err := ssz.EncodeToStream(str1, T(new(U)), fork); err != nil {
+	if err := ssz.EncodeToStreamOnFork(str1, T(new(U)), fork); err != nil {
 		t.Fatalf("failed to stream-encode zero-value object: %v", err)
 	}
-	bin1 := make([]byte, ssz.Size(T(new(U)), fork))
-	if err := ssz.EncodeToBytes(bin1, T(new(U)), fork); err != nil {
+	bin1 := make([]byte, ssz.SizeOnFork(T(new(U)), fork))
+	if err := ssz.EncodeToBytesOnFork(bin1, T(new(U)), fork); err != nil {
 		t.Fatalf("failed to buffer-encode zero-value object: %v", err)
 	}
 	if !bytes.Equal(str1.Bytes(), bin1) {
@@ -32,11 +32,11 @@ func testZeroValue[T newableObject[U], U any](t *testing.T, fork ssz.Fork) {
 	// Decode the previous encoding in both streaming/buffering mode and check
 	// that the produced objects are the same.
 	obj1 := T(new(U))
-	if err := ssz.DecodeFromStream(bytes.NewReader(bin1), T(new(U)), uint32(len(bin1)), fork); err != nil {
+	if err := ssz.DecodeFromStreamOnFork(bytes.NewReader(bin1), T(new(U)), uint32(len(bin1)), fork); err != nil {
 		t.Fatalf("failed to stream-decode zero-value object: %v", err)
 	}
 	obj2 := T(new(U))
-	if err := ssz.DecodeFromBytes(bin1, T(new(U)), fork); err != nil {
+	if err := ssz.DecodeFromBytesOnFork(bin1, T(new(U)), fork); err != nil {
 		t.Fatalf("failed to buffer-decode zero-value object: %v", err)
 	}
 	if !reflect.DeepEqual(obj1, obj2) {
@@ -46,11 +46,11 @@ func testZeroValue[T newableObject[U], U any](t *testing.T, fork ssz.Fork) {
 	// nil-ness might be different. To verify that the decoding was successful, do
 	// yet another round of encodings and check that to the original ones.
 	str2 := new(bytes.Buffer)
-	if err := ssz.EncodeToStream(str2, obj1, fork); err != nil {
+	if err := ssz.EncodeToStreamOnFork(str2, obj1, fork); err != nil {
 		t.Fatalf("failed to stream-encode decoded object: %v", err)
 	}
-	bin2 := make([]byte, ssz.Size(obj1, fork))
-	if err := ssz.EncodeToBytes(bin2, obj1, fork); err != nil {
+	bin2 := make([]byte, ssz.SizeOnFork(obj1, fork))
+	if err := ssz.EncodeToBytesOnFork(bin2, obj1, fork); err != nil {
 		t.Fatalf("failed to buffer-encode decoded object: %v", err)
 	}
 	if !bytes.Equal(str2.Bytes(), bin2) {
@@ -62,10 +62,10 @@ func testZeroValue[T newableObject[U], U any](t *testing.T, fork ssz.Fork) {
 	// Encoding/decoding seems to work, hash the zero-value and re-encoded value
 	// in both sequential/concurrent more and verify the results.
 	hashes := map[string][32]byte{
-		"zero-value-sequential": ssz.HashSequential(T(new(U)), fork),
-		"zero-value-concurrent": ssz.HashConcurrent(T(new(U)), fork),
-		"decoded-sequential":    ssz.HashSequential(obj1, fork),
-		"decoded-concurrent":    ssz.HashSequential(obj1, fork),
+		"zero-value-sequential": ssz.HashSequentialOnFork(T(new(U)), fork),
+		"zero-value-concurrent": ssz.HashConcurrentOnFork(T(new(U)), fork),
+		"decoded-sequential":    ssz.HashSequentialOnFork(obj1, fork),
+		"decoded-concurrent":    ssz.HashSequentialOnFork(obj1, fork),
 	}
 	for key1, hash1 := range hashes {
 		for key2, hash2 := range hashes {


### PR DESCRIPTION
Add the documentation for the monolith types, restore the non-monolith API to not be so drastic with users.